### PR TITLE
fix(kerchunkd): daemon exits immediately on restart due to set -e short-circuit

### DIFF
--- a/app_rpt/bin/kerchunkd.sh
+++ b/app_rpt/bin/kerchunkd.sh
@@ -147,6 +147,7 @@ log_kerchunk_stats() {
 }
 
 play_kerchunk_warning() {
+    sleep 2
     log "Playing kerchunk reminder message (consecutive: ${CONSECUTIVE})"
 
     # Check if we have a custom message

--- a/app_rpt/bin/kerchunkd.sh
+++ b/app_rpt/bin/kerchunkd.sh
@@ -47,6 +47,9 @@ KERCHUNK_THRESHOLD="${KERCHUNK_THRESHOLD:-3}"
 # Rate limiting (seconds between warning messages)
 KERCHUNK_WAITLIMIT="${KERCHUNK_WAITLIMIT:-30}"
 
+# Delay (seconds) after COS drops before playing the warning
+KERCHUNK_WARNDELAY="${KERCHUNK_WARNDELAY:-2}"
+
 # Kerchunk duration range (seconds)
 KERCHUNK_MIN_DURATION="${KERCHUNK_MIN_DURATION:-0.2}"  # Minimum duration to count (ignore noise/blips)
 KERCHUNK_MAX_DURATION="${KERCHUNK_MAX_DURATION:-1.5}"  # Maximum duration - anything over this resets counter
@@ -147,7 +150,7 @@ log_kerchunk_stats() {
 }
 
 play_kerchunk_warning() {
-    sleep 2
+    sleep "${KERCHUNK_WARNDELAY}"
     log "Playing kerchunk reminder message (consecutive: ${CONSECUTIVE})"
 
     # Check if we have a custom message
@@ -250,7 +253,7 @@ _loop_iteration() {
 }
 
 main_loop() {
-    log "Kerchunk daemon started (poll: ${POLL_INTERVAL}s, mode: ${KERCHUNK_MODE}, threshold: ${KERCHUNK_THRESHOLD}, duration: ${KERCHUNK_MIN_DURATION}-${KERCHUNK_MAX_DURATION}s)"
+    log "Kerchunk daemon started (poll: ${POLL_INTERVAL}s, mode: ${KERCHUNK_MODE}, threshold: ${KERCHUNK_THRESHOLD}, duration: ${KERCHUNK_MIN_DURATION}-${KERCHUNK_MAX_DURATION}s, warndelay: ${KERCHUNK_WARNDELAY}s)"
 
     # Initialize state
     initialize_state

--- a/app_rpt/bin/kerchunkd.sh
+++ b/app_rpt/bin/kerchunkd.sh
@@ -122,7 +122,12 @@ initialize_state() {
     [[ -f "${LAST_WARNING_FILE}" ]] || echo "0" > "${LAST_WARNING_FILE}"
     [[ -f "${LAST_KEYUPS_FILE}" ]] || echo "0" > "${LAST_KEYUPS_FILE}"
     [[ -f "${LAST_TXTIME_FILE}" ]] || echo "0" > "${LAST_TXTIME_FILE}"
-    [[ -f "${LAST_KERCHUNKS_FILE}" ]] || echo "0" > "${LAST_KERCHUNKS_FILE}"
+    if [[ ! -f "${LAST_KERCHUNKS_FILE}" ]]; then
+        local cur_kerchunks
+        cur_kerchunks=$(asterisk -rx "rpt stats ${MYNODE}" 2>/dev/null | grep "Kerchunks since system initialization" | awk -F: '{print $2}' | tr -d ' ')
+        [[ "$cur_kerchunks" =~ ^[0-9]+$ ]] || cur_kerchunks="0"
+        echo "$cur_kerchunks" > "${LAST_KERCHUNKS_FILE}"
+    fi
 }
 
 read_state() {

--- a/app_rpt/bin/kerchunkd.sh
+++ b/app_rpt/bin/kerchunkd.sh
@@ -64,6 +64,7 @@ CONSECUTIVE_FILE="${STATE_DIR}/consecutive"
 LAST_WARNING_FILE="${STATE_DIR}/last_warning"
 LAST_KEYUPS_FILE="${STATE_DIR}/last_keyups"
 LAST_TXTIME_FILE="${STATE_DIR}/last_txtime"
+LAST_KERCHUNKS_FILE="${STATE_DIR}/last_kerchunks"
 
 # ==============================================================================
 #    Functions
@@ -89,7 +90,7 @@ txtime_to_ms() {
 }
 
 get_stats() {
-    # Get current keyups and TX time from rpt stats
+    # Get current keyups, TX time, and kerchunks from rpt stats
     local stats
     stats=$(asterisk -rx "rpt stats ${MYNODE}" 2>/dev/null)
 
@@ -97,6 +98,11 @@ get_stats() {
     local keyups
     keyups=$(echo "$stats" | grep "Keyups since system initialization" | awk -F: '{print $2}' | tr -d ' ')
     [[ "$keyups" =~ ^[0-9]+$ ]] || keyups="0"
+
+    # Extract kerchunks (RF-only, excludes node connect events)
+    local kerchunks
+    kerchunks=$(echo "$stats" | grep "Kerchunks since system initialization" | awk -F: '{print $2}' | tr -d ' ')
+    [[ "$kerchunks" =~ ^[0-9]+$ ]] || kerchunks="0"
 
     # Extract TX time
     local txtime
@@ -107,7 +113,7 @@ get_stats() {
     local txtime_ms
     txtime_ms=$(txtime_to_ms "$txtime")
 
-    echo "${keyups}:${txtime_ms}"
+    echo "${keyups}:${txtime_ms}:${kerchunks}"
 }
 
 initialize_state() {
@@ -116,6 +122,7 @@ initialize_state() {
     [[ -f "${LAST_WARNING_FILE}" ]] || echo "0" > "${LAST_WARNING_FILE}"
     [[ -f "${LAST_KEYUPS_FILE}" ]] || echo "0" > "${LAST_KEYUPS_FILE}"
     [[ -f "${LAST_TXTIME_FILE}" ]] || echo "0" > "${LAST_TXTIME_FILE}"
+    [[ -f "${LAST_KERCHUNKS_FILE}" ]] || echo "0" > "${LAST_KERCHUNKS_FILE}"
 }
 
 read_state() {
@@ -123,6 +130,7 @@ read_state() {
     LAST_WARNING=$(cat "${LAST_WARNING_FILE}" 2>/dev/null || echo "0")
     LAST_KEYUPS=$(cat "${LAST_KEYUPS_FILE}" 2>/dev/null || echo "0")
     LAST_TXTIME=$(cat "${LAST_TXTIME_FILE}" 2>/dev/null || echo "0")
+    LAST_KERCHUNKS=$(cat "${LAST_KERCHUNKS_FILE}" 2>/dev/null || echo "0")
 }
 
 write_state() {
@@ -130,6 +138,7 @@ write_state() {
     echo "${LAST_WARNING}" > "${LAST_WARNING_FILE}"
     echo "${LAST_KEYUPS}" > "${LAST_KEYUPS_FILE}"
     echo "${LAST_TXTIME}" > "${LAST_TXTIME_FILE}"
+    echo "${LAST_KERCHUNKS}" > "${LAST_KERCHUNKS_FILE}"
 }
 
 log_kerchunk_stats() {
@@ -184,71 +193,81 @@ _loop_iteration() {
     # Read current state
     read_state
 
-    # Get current stats (keyups:txtime_ms)
+    # Get current stats (keyups:txtime_ms:kerchunks)
     local stats
     stats=$(get_stats)
     local current_keyups
     current_keyups=$(echo "$stats" | cut -d: -f1)
     local current_txtime
     current_txtime=$(echo "$stats" | cut -d: -f2)
+    local current_kerchunks
+    current_kerchunks=$(echo "$stats" | cut -d: -f3)
 
-    # Check if keyups increased
-    if [[ $current_keyups -gt $LAST_KEYUPS ]]; then
-        # New transmission(s) detected
-        local new_keyups=$((current_keyups - LAST_KEYUPS))
+    local new_kerchunks=$((current_kerchunks - LAST_KERCHUNKS))
+    local new_keyups=$((current_keyups - LAST_KEYUPS))
+
+    if [[ $new_kerchunks -gt 0 ]]; then
+        # app_rpt classified this as a kerchunk (RF-only, node connects excluded)
+        local avg_duration_s="n/a"
+        if [[ $new_keyups -gt 0 ]]; then
+            local txtime_delta_ms=$((current_txtime - LAST_TXTIME))
+            local avg_duration_ms=$((txtime_delta_ms / new_keyups))
+            avg_duration_s=$(awk "BEGIN {printf \"%.1f\", $avg_duration_ms/1000.0}")
+        fi
+
+        CONSECUTIVE=$((CONSECUTIVE + new_kerchunks))
+        log "Kerchunk detected (duration: ${avg_duration_s}s, consecutive: ${CONSECUTIVE})"
+
+        if [[ $CONSECUTIVE -ge $KERCHUNK_THRESHOLD ]]; then
+            log "Kerchunk threshold reached (${CONSECUTIVE} >= ${KERCHUNK_THRESHOLD})"
+
+            if [[ "$KERCHUNK_MODE" == "active" ]]; then
+                if check_rate_limit; then
+                    play_kerchunk_warning
+                    log_kerchunk_stats "$avg_duration_s" "$CONSECUTIVE" "yes" "kerchunk"
+                    LAST_WARNING=$(date +%s)
+                    CONSECUTIVE=0
+                else
+                    log_kerchunk_stats "$avg_duration_s" "$CONSECUTIVE" "no" "kerchunk"
+                fi
+            else
+                log "Passive mode: kerchunks logged, no warning played"
+                log_kerchunk_stats "$avg_duration_s" "$CONSECUTIVE" "no-passive" "kerchunk"
+                CONSECUTIVE=0
+            fi
+        else
+            log_kerchunk_stats "$avg_duration_s" "$CONSECUTIVE" "no" "kerchunk"
+        fi
+
+    elif [[ $new_keyups -gt 0 ]]; then
+        # Keyups increased but kerchunks counter didn't — use duration to decide
+        # whether this is a normal transmission (reset counter) or a non-RF event
+        # like a node connect (ignore entirely)
         local txtime_delta_ms=$((current_txtime - LAST_TXTIME))
-
-        # Calculate average duration per transmission in this poll cycle
         local avg_duration_ms=$((txtime_delta_ms / new_keyups))
         local avg_duration_s=$(awk "BEGIN {printf \"%.1f\", $avg_duration_ms/1000.0}")
 
-        # Convert duration thresholds to milliseconds for comparison
         local kerchunk_min_ms=$(awk "BEGIN {printf \"%.0f\", $KERCHUNK_MIN_DURATION*1000}")
         local kerchunk_max_ms=$(awk "BEGIN {printf \"%.0f\", $KERCHUNK_MAX_DURATION*1000}")
 
         if [[ $avg_duration_ms -lt $kerchunk_min_ms ]]; then
-            # Too short - ignore (noise/blip), don't affect counter
+            # Too short — noise/blip, ignore
             log "Transmission too short (duration: ${avg_duration_s}s < ${KERCHUNK_MIN_DURATION}s, ignored)"
-        elif [[ $avg_duration_ms -le $kerchunk_max_ms ]]; then
-            # Kerchunk detected (within MIN-MAX range)
-            CONSECUTIVE=$((CONSECUTIVE + new_keyups))
-            log "Kerchunk detected (duration: ${avg_duration_s}s in ${KERCHUNK_MIN_DURATION}-${KERCHUNK_MAX_DURATION}s range, consecutive: ${CONSECUTIVE})"
-
-            # Check if we've reached the threshold
-            if [[ $CONSECUTIVE -ge $KERCHUNK_THRESHOLD ]]; then
-                log "Kerchunk threshold reached (${CONSECUTIVE} >= ${KERCHUNK_THRESHOLD})"
-
-                # Check if active mode (play warning) or passive mode (log only)
-                if [[ "$KERCHUNK_MODE" == "active" ]]; then
-                    # Active mode: play warning message
-                    if check_rate_limit; then
-                        play_kerchunk_warning
-                        log_kerchunk_stats "$avg_duration_s" "$CONSECUTIVE" "yes" "kerchunk"
-                        LAST_WARNING=$(date +%s)
-                        CONSECUTIVE=0  # Reset after warning
-                    else
-                        log_kerchunk_stats "$avg_duration_s" "$CONSECUTIVE" "no" "kerchunk"
-                    fi
-                else
-                    # Passive mode: log only, no warning played
-                    log "Passive mode: kerchunks logged, no warning played"
-                    log_kerchunk_stats "$avg_duration_s" "$CONSECUTIVE" "no-passive" "kerchunk"
-                    CONSECUTIVE=0  # Reset after threshold in passive mode too
-                fi
-            else
-                log_kerchunk_stats "$avg_duration_s" "$CONSECUTIVE" "no" "kerchunk"
-            fi
-        else
-            # Normal transmission (> MAX) - reset consecutive counter
+        elif [[ $avg_duration_ms -gt $kerchunk_max_ms ]]; then
+            # Long enough to be a normal transmission — reset consecutive counter
             log "Normal transmission detected (duration: ${avg_duration_s}s > ${KERCHUNK_MAX_DURATION}s, consecutive reset)"
             log_kerchunk_stats "$avg_duration_s" "0" "no" "normal"
             CONSECUTIVE=0
+        else
+            # In kerchunk duration range but not counted by app_rpt — non-RF event (e.g. node connect), ignore
+            log "Non-RF event ignored (duration: ${avg_duration_s}s, not counted as kerchunk by app_rpt)"
         fi
     fi
 
     # Update state
     LAST_KEYUPS=$current_keyups
     LAST_TXTIME=$current_txtime
+    LAST_KERCHUNKS=$current_kerchunks
     write_state
 }
 

--- a/app_rpt/bin/kerchunkd.sh
+++ b/app_rpt/bin/kerchunkd.sh
@@ -93,12 +93,12 @@ get_stats() {
     # Extract keyups
     local keyups
     keyups=$(echo "$stats" | grep "Keyups since system initialization" | awk -F: '{print $2}' | tr -d ' ')
-    [[ -z "$keyups" ]] || [[ ! "$keyups" =~ ^[0-9]+$ ]] && keyups="0"
+    [[ "$keyups" =~ ^[0-9]+$ ]] || keyups="0"
 
     # Extract TX time
     local txtime
     txtime=$(echo "$stats" | grep "TX time since system initialization" | awk -F: '{print $2":"$3":"$4":"$5}' | tr -d ' ')
-    [[ -z "$txtime" ]] && txtime="00:00:00:000"
+    [[ -n "$txtime" ]] || txtime="00:00:00:000"
 
     # Convert TX time to milliseconds
     local txtime_ms
@@ -109,10 +109,10 @@ get_stats() {
 
 initialize_state() {
     mkdir -p "${STATE_DIR}"
-    [[ ! -f "${CONSECUTIVE_FILE}" ]] && echo "0" > "${CONSECUTIVE_FILE}"
-    [[ ! -f "${LAST_WARNING_FILE}" ]] && echo "0" > "${LAST_WARNING_FILE}"
-    [[ ! -f "${LAST_KEYUPS_FILE}" ]] && echo "0" > "${LAST_KEYUPS_FILE}"
-    [[ ! -f "${LAST_TXTIME_FILE}" ]] && echo "0" > "${LAST_TXTIME_FILE}"
+    [[ -f "${CONSECUTIVE_FILE}" ]] || echo "0" > "${CONSECUTIVE_FILE}"
+    [[ -f "${LAST_WARNING_FILE}" ]] || echo "0" > "${LAST_WARNING_FILE}"
+    [[ -f "${LAST_KEYUPS_FILE}" ]] || echo "0" > "${LAST_KEYUPS_FILE}"
+    [[ -f "${LAST_TXTIME_FILE}" ]] || echo "0" > "${LAST_TXTIME_FILE}"
 }
 
 read_state() {


### PR DESCRIPTION
## Summary

`kerchunkd.service` enters an infinite restart loop after its first run. The daemon logs "Kerchunk daemon started" then immediately exits with status 1 — the monitoring `while` loop never executes.

- **Root cause:** `set -euo pipefail` is active throughout the script. A `[[ condition ]] && command` expression that **short-circuits** (condition is false, so command never runs) returns exit code **1**. Bash treats this as a failure and exits the script.
- **Primary crash site:** `initialize_state()` — on every run after the first, all four state files already exist, so all four `[[ ! -f ... ]] && echo` lines short-circuit to 1, killing the daemon before the loop starts.
- **Secondary sites:** two similar patterns in `get_stats()` that return 1 when `keyups` and `txtime` are valid (non-empty) values.

## Fix 1: `set -e` short-circuit crash

Replace `[[ ! -f file ]] && cmd` with `[[ -f file ]] || cmd` (and equivalent flips for the other two). The `||` form returns **0** whether the short-circuit path is taken or not, so `set -e` is satisfied in both cases.

```bash
# initialize_state() — before
[[ ! -f "${CONSECUTIVE_FILE}" ]] && echo "0" > "${CONSECUTIVE_FILE}"

# after
[[ -f "${CONSECUTIVE_FILE}" ]] || echo "0" > "${CONSECUTIVE_FILE}"
```

```bash
# get_stats() — before
[[ -z "$keyups" ]] || [[ ! "$keyups" =~ ^[0-9]+$ ]] && keyups="0"
[[ -z "$txtime" ]] && txtime="00:00:00:000"

# after
[[ "$keyups" =~ ^[0-9]+$ ]] || keyups="0"
[[ -n "$txtime" ]] || txtime="00:00:00:000"
```

## Fix 2: Configurable post-COS delay before warning

During testing with `KERCHUNK_MODE=active`, the warning audio played immediately as the transmission dropped, cutting over the repeater tail. A new `KERCHUNK_WARNDELAY` config variable (default: 2s) controls how long the daemon waits after COS drops before playing the warning.

```ini
# config.ini
KERCHUNK_WARNDELAY=2       # Seconds to wait after COS drops before playing warning
```

```bash
# play_kerchunk_warning() — before
play_kerchunk_warning() {
    log "Playing kerchunk reminder message (consecutive: ${CONSECUTIVE})"
    ...
}

# after
play_kerchunk_warning() {
    sleep "${KERCHUNK_WARNDELAY}"
    log "Playing kerchunk reminder message (consecutive: ${CONSECUTIVE})"
    ...
}
```

The value is also surfaced in the startup log line:

```
Kerchunk daemon started (poll: 1s, mode: active, threshold: 3, duration: 0.2-1.5s, warndelay: 2s)
```

## Fix 3: Node connect events triggering the warning

Connecting a node via the web interface triggered the "please identify" warning. The daemon was monitoring the `Keyups since system initialization` counter and calculating duration itself — node connect events increment keyups but are not RF transmissions.

**Fix:** Switch kerchunk detection to the `Kerchunks since system initialization` counter from `rpt stats`, which app_rpt maintains as RF-only. The keyups counter and duration thresholds (`KERCHUNK_MIN_DURATION`, `KERCHUNK_MAX_DURATION`) are retained to identify normal transmissions that reset the consecutive counter. Non-RF keyup events fall in between and are logged and ignored:

```
Non-RF event ignored (duration: 1.2s, not counted as kerchunk by app_rpt)
```

A new `last_kerchunks` state file tracks the counter between polls. On first creation it is seeded with the current live value (not 0) to prevent the full historical kerchunk count from appearing as "new" on the first poll after install or service restart.

## Tested On

Both fixes verified working on the following hardware/software:

| | |
|---|---|
| **Hardware** | Raspberry Pi 5 (aarch64) |
| **OS** | Debian GNU/Linux 13 (trixie) |
| **Kernel** | 6.18.29+rpt-rpi-2712 |
| **ASL3** | 3.18.2-2.deb13 |
| **Asterisk** | 22.9.0+asl3-3.9.3-1.deb13 |
| **app_rpt__ultra** | 2.0.8 |
| **Node** | 65659 |

## Reproduction

Observed on node 65659 (`repeater-asl3`). By the time it was caught, the service had restarted **4,100+ times**. Confirmed with `bash -x`: execution halts on the last `[[ ! -f ... ]]` line in `initialize_state()` with no further trace output.

## Test plan

- [x] Deploy fix to affected node and confirm `kerchunkd.service` stays running past the first poll cycle
- [x] Verify "Kerchunk daemon started" is no longer immediately followed by "Kerchunk daemon stopped" in `app_rpt.log`
- [x] Confirm `KERCHUNK_WARNDELAY` in `config.ini` controls the post-COS pause before the warning plays
- [x] Confirm node connect events no longer trigger the warning
- [x] Confirm no regression in passive and active kerchunk detection modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)